### PR TITLE
feat: Rename root .env file to .env.secret-agents with CLI override

### DIFF
--- a/.env.secret-agents
+++ b/.env.secret-agents
@@ -1,0 +1,39 @@
+# Linear Agent Configuration
+LINEAR_WEBHOOK_SECRET=secret_xxx
+
+# Choose one authentication method:
+# Option 1: API Token
+LINEAR_API_TOKEN=lin_api_xxx
+
+# Option 2: OAuth (recommended for agents)
+# LINEAR_OAUTH_CLIENT_ID=client_xxx
+# LINEAR_OAUTH_CLIENT_SECRET=secret_xxx
+# LINEAR_OAUTH_REDIRECT_URI=https://your-ngrok-url.ngrok.io/oauth/callback
+
+# Option 3: Personal Access Token
+# LINEAR_PERSONAL_ACCESS_TOKEN=pat_xxx
+
+# Server Configuration
+WEBHOOK_PORT=3000
+
+# Claude Configuration
+CLAUDE_PATH=/usr/local/bin/claude
+# Required if you don't have Claude Max with authenticated CLI
+ANTHROPIC_API_KEY=sk-ant-xxxxxxx
+
+# Tool permissions (optional)
+# CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep,LS,WebFetch,TodoRead,NotebookRead,Task,Batch
+# CLAUDE_READ_ONLY=true
+
+# Workspace Configuration
+WORKSPACE_BASE_DIR=/path/to/workspaces
+PROMPT_TEMPLATE_PATH=/path/to/prompt-template.txt
+# Git main branch name (optional, defaults to 'main')
+# GIT_MAIN_BRANCH=main
+
+# Debug Options (all optional, default to false)
+# DEBUG_WEBHOOKS=true
+# DEBUG_SELF_WEBHOOKS=true
+# DEBUG_LINEAR_API=true
+# DEBUG_CLAUDE_RESPONSES=true
+# DEBUG_COMMENT_CONTENT=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- CLI argument `--env-file`/`-e` to specify custom environment file
+- Default environment file changed from `.env` to `.env.secret-agents`
+
+### Changed
+- All entry points now support custom environment file paths
+- Updated documentation to reflect new environment file behavior

--- a/README.md
+++ b/README.md
@@ -98,13 +98,15 @@ This approach ensures continuous context while being efficient with token usage.
 ## Setup
 
 1. Clone this repository
-2. Create a `.env` file based on `.env.example`
+2. Create a `.env.secret-agents` file based on `.env.example`
 3. Fill in your Linear API token, user ID, and webhook secret
 4. Install dependencies with `npm install`
 5. Optional: Install globally with `npm install -g .` (allows running `linear-claude-agent` from any directory)
 6. Start the agent with `npm start` or `linear-claude-agent` if installed globally
 
 ## Environment Variables
+
+By default, the agent looks for a `.env.secret-agents` file in the current directory. You can specify a different file using the `--env-file` option when running the agent.
 
 ### Required Variables
 
@@ -194,9 +196,16 @@ See the [Linear Webhooks documentation](https://developers.linear.app/docs/webho
 
 There are several ways to run the agent:
 
-1. **Standard Mode**:
+1. **Standard Mode** (uses `.env.secret-agents` by default):
    ```
    npm start
+   ```
+   
+   Or with a custom environment file:
+   ```
+   npm start -- --env-file .env.custom
+   # or
+   linear-claude-agent --env-file .env.custom
    ```
 
 2. **Development Mode** (auto-restart on file changes):
@@ -208,6 +217,8 @@ There are several ways to run the agent:
    ```
    # Start an OAuth authorization server
    node scripts/start-auth-server.mjs
+   # or with custom env file:
+   node scripts/start-auth-server.mjs --env-file .env.custom
    
    # Start ngrok in another terminal
    ngrok http 3000
@@ -218,7 +229,11 @@ There are several ways to run the agent:
 
 4. **OAuth Reset** (if you need to reauthorize):
    ```
-   # Visit in your browser (replace with your ngrok URL):
+   node scripts/reset-oauth.mjs
+   # or with custom env file:
+   node scripts/reset-oauth.mjs --env-file .env.custom
+   
+   # Then visit in your browser (replace with your ngrok URL):
    # https://your-ngrok-url.ngrok.io/oauth/reset
    ```
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,8 +1,45 @@
 #!/usr/bin/env node
 import { App } from './src/app.mjs';
+import { parseArgs } from 'node:util';
 
-// Create the application
-const app = new App();
+// Parse command line arguments
+const options = {
+  'env-file': {
+    type: 'string',
+    short: 'e',
+    default: '.env.secret-agents',
+    description: 'Path to the environment file'
+  },
+  help: {
+    type: 'boolean',
+    short: 'h',
+    description: 'Show help'
+  }
+};
+
+let values;
+try {
+  const parsed = parseArgs({ options, allowPositionals: false });
+  values = parsed.values;
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+}
+
+// Show help if requested
+if (values.help) {
+  console.log(`
+Usage: linear-claude-agent [options]
+
+Options:
+  -e, --env-file <path>    Path to the environment file (default: .env.secret-agents)
+  -h, --help               Show help
+`);
+  process.exit(0);
+}
+
+// Create the application with the env file path
+const app = new App(values['env-file']);
 let isShuttingDown = false;
 
 // Graceful shutdown handler

--- a/scripts/reset-oauth.mjs
+++ b/scripts/reset-oauth.mjs
@@ -2,15 +2,35 @@
 
 /**
  * Utility script to reset OAuth tokens and other persistence files
- * Run with: node scripts/reset-oauth.mjs
+ * Run with: node scripts/reset-oauth.mjs [--env-file <path>]
  */
 
 import fs from 'fs-extra';
 import path from 'path';
 import dotenv from 'dotenv';
+import { parseArgs } from 'node:util';
 
-// Load environment variables
-dotenv.config();
+// Parse command line arguments
+const options = {
+  'env-file': {
+    type: 'string',
+    short: 'e',
+    default: '.env.secret-agents',
+    description: 'Path to the environment file'
+  }
+};
+
+let values;
+try {
+  const parsed = parseArgs({ options, allowPositionals: false });
+  values = parsed.values;
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+}
+
+// Load environment variables from the specified file
+dotenv.config({ path: values['env-file'] });
 
 // Get the workspace base directory from environment
 const baseDir = process.env.WORKSPACE_BASE_DIR || './workspaces';

--- a/scripts/start-auth-server.mjs
+++ b/scripts/start-auth-server.mjs
@@ -2,7 +2,7 @@
 
 /**
  * Utility script to start just the OAuth authorization server
- * Run with: node scripts/start-auth-server.mjs
+ * Run with: node scripts/start-auth-server.mjs [--env-file <path>]
  */
 
 import express from 'express';
@@ -10,9 +10,29 @@ import dotenv from 'dotenv';
 import { OAuthHelper } from '../src/utils/OAuthHelper.mjs';
 import { FileSystem } from '../src/utils/FileSystem.mjs';
 import fetch from 'node-fetch'; // Ensure node-fetch is used in Node.js environment
+import { parseArgs } from 'node:util';
 
-// Load environment variables
-dotenv.config();
+// Parse command line arguments
+const options = {
+  'env-file': {
+    type: 'string',
+    short: 'e',
+    default: '.env.secret-agents',
+    description: 'Path to the environment file'
+  }
+};
+
+let values;
+try {
+  const parsed = parseArgs({ options, allowPositionals: false });
+  values = parsed.values;
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+}
+
+// Load environment variables from the specified file
+dotenv.config({ path: values['env-file'] });
 
 // Initialize dependencies
 const fileSystem = new FileSystem();

--- a/src/app.mjs
+++ b/src/app.mjs
@@ -1,11 +1,14 @@
-import 'dotenv/config';
+import dotenv from 'dotenv';
 import { createContainer } from './container.mjs';
 
 /**
  * Application class that orchestrates the components
  */
 export class App {
-  constructor() {
+  constructor(envFilePath = '.env.secret-agents') {
+    // Load environment variables from the specified file
+    dotenv.config({ path: envFilePath });
+    
     this.container = createContainer();
     this.webhookServer = null;
     this.isShuttingDown = false;


### PR DESCRIPTION
## Summary
- Introduces a CLI argument to specify custom environment file with default to `.env.secret-agents`
- Allows the env file name to be overridden via `--env-file` command line option
- Updates all entry points to support the new functionality

## Changes
- Added `--env-file`/`-e` CLI argument to `index.mjs` with default value `.env.secret-agents`
- Updated `app.mjs` to accept and use the custom env file path
- Updated both OAuth scripts (`start-auth-server.mjs` and `reset-oauth.mjs`) to support custom env files
- Created `.env.secret-agents` example file
- Updated README.md documentation with new environment file information

## Test plan
- [x] Run `node index.mjs --help` to verify help output
- [x] Run tests with `npm test` to ensure no regressions
- [ ] Test with default `.env.secret-agents` file
- [ ] Test with custom env file using `--env-file` option
- [ ] Test OAuth scripts with custom env file

🤖 Generated with [Claude Code](https://claude.ai/code)