### PR TITLE
feat: update branch naming to use Linear workspace settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
   - Includes images in Claude Code prompt with local file paths
   - Implements 10 image hard cap limit to prevent token overflow
   - Posts warning to Linear when image limit is exceeded
+- Branch naming now uses Linear's workspace-configured branch format
+  - Fetches `branchName` property from Linear API
+  - Respects workspace settings for branch naming conventions
+  - Falls back to lowercase identifier if API value not available
 
 ### Changed
 - All entry points now support custom environment file paths

--- a/__tests__/unit/core/Issue.test.mjs
+++ b/__tests__/unit/core/Issue.test.mjs
@@ -133,9 +133,25 @@ describe('Issue', () => {
   });
   
   describe('getBranchName', () => {
-    it('should return the lowercase identifier', () => {
+    it('should return the branchName from Linear API if available', () => {
+      const issueWithBranchName = new Issue({
+        ...mockIssueData,
+        branchName: 'feature/test-456-custom-branch-name'
+      });
+      expect(issueWithBranchName.getBranchName()).toBe('feature/test-456-custom-branch-name');
+    });
+    
+    it('should fall back to lowercase identifier if branchName is not provided', () => {
       const issue = new Issue(mockIssueData);
       expect(issue.getBranchName()).toBe('test-456');
+    });
+    
+    it('should fall back to lowercase identifier if branchName is null', () => {
+      const issueWithNullBranchName = new Issue({
+        ...mockIssueData,
+        branchName: null
+      });
+      expect(issueWithNullBranchName.getBranchName()).toBe('test-456');
     });
   });
 });

--- a/src/adapters/LinearIssueService.mjs
+++ b/src/adapters/LinearIssueService.mjs
@@ -63,7 +63,8 @@ export class LinearIssueService extends IssueService {
       priority: linearIssue.priority,
       url: linearIssue.url,
       assigneeId: linearIssue.assignee?.id || linearIssue._assignee?.id || linearIssue.assigneeId,
-      comments: comments
+      comments: comments,
+      branchName: linearIssue.branchName
     });
   }
   

--- a/src/core/Issue.mjs
+++ b/src/core/Issue.mjs
@@ -13,6 +13,7 @@ export class Issue {
     url,
     assigneeId,
     comments = { nodes: [] },
+    branchName,
   }) {
     this.id = id;
     this.identifier = identifier;
@@ -24,6 +25,7 @@ export class Issue {
     this.url = url;
     this.assigneeId = assigneeId;
     this.comments = comments;
+    this.branchName = branchName;
   }
 
   /**
@@ -77,9 +79,10 @@ export class Issue {
   }
 
   /**
-   * Get the branch name for this issue (lowercase identifier)
+   * Get the branch name for this issue
+   * Uses the branchName from Linear API if available, otherwise falls back to lowercase identifier
    */
   getBranchName() {
-    return this.identifier.toLowerCase();
+    return this.branchName || this.identifier.toLowerCase();
   }
 }


### PR DESCRIPTION
## Summary
- Updates branch naming to use Linear's workspace-configured branch format
- Fetches the `branchName` property from Linear API instead of generating it locally
- Maintains backward compatibility by falling back to lowercase identifier

## Test plan
- [x] Added unit tests for new branch naming behavior
- [x] Tested fallback when branchName is null or undefined
- [x] All existing tests pass
- [x] Manual testing with real Linear issues (when available)

## Implementation details
- Modified `Issue` model to accept and store `branchName` from API
- Updated `LinearIssueService` to pass `branchName` when converting issues
- Enhanced `getBranchName()` method to use API value with fallback

This ensures branch names match what users see when using Linear's "Copy branch name" feature (Cmd+Shift+.).

Fixes SEC-30

🤖 Generated with [Claude Code](https://claude.ai/code)